### PR TITLE
fixed in_vocab count issue!

### DIFF
--- a/mimick/make_dataset.py
+++ b/mimick/make_dataset.py
@@ -77,7 +77,6 @@ if __name__ == "__main__":
 
     # Test
     if len(vocab) > 0:
-        in_vocab = 0
         total = len(vocab)
         for v in vocab:
             if v not in words:

--- a/mimick/make_dataset.py
+++ b/mimick/make_dataset.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     print "Total in Embeddings vocabulary:", len(words)
     print "Training set character count: ", training_char_count
 
-    # Test
+    # Test: Will be doing inference on these words using mimick
     if len(vocab) > 0:
         total = len(vocab)
         for v in vocab:

--- a/mimick/make_dataset.py
+++ b/mimick/make_dataset.py
@@ -81,10 +81,10 @@ if __name__ == "__main__":
         for v in vocab:
             if v not in words:
                 test_instances.append(Instance(charseq(v, c2i), np.array([0.0] * dim)))
-        print "Total Number of output words:", total
-        print "Total in Training Vocabulary:", in_vocab
-        print "Percentage in-vocab:", in_vocab / total
-        print "Total character count: ", len(c2i)
+    print "Total Number of output words:", total
+    print "Total in Training Vocabulary:", in_vocab
+    print "Percentage in-vocab:", in_vocab / total
+    print "Total character count: ", len(c2i)
 
     c2i[PADDING_CHAR] = len(c2i)
 


### PR DESCRIPTION
removed the unnecessary re-initialization for `in_vocab`, made sure the code prints the stats even when test set instances are absent. Added a small note that test set instances are actually used for **inference** using `mimick`.